### PR TITLE
Smaller fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
 	<div id="app">
-		<b-navbar sticky toggleable="md" type="dark" variant="hest" class="shadow">
+		<b-navbar sticky toggleable="xl" type="dark" variant="hest" class="shadow">
 			<b-navbar-brand href="/" class="mb-0 pb-0 pt-0">
 				<img src="./assets/logo_cropped.png" style="width: 50px;" />
 			</b-navbar-brand>
@@ -23,7 +23,6 @@
 						<b-nav-item :to="link.page">{{ link.text }}</b-nav-item>
 					</div>
 				</b-navbar-nav>
-
 			</b-collapse>
 		</b-navbar>
 		<div id="content">
@@ -41,11 +40,19 @@
 					</span>
 				</p>
 				<p class="m-0">
-					<a class="pl-0" style="font-size: 0.8rem;" href="mailto:henriette.steenhoff@gmail.com?subject=CookingAssistant" target="_blank"
+					<a
+						class="pl-0"
+						style="font-size: 0.8rem;"
+						href="mailto:henriette.steenhoff@gmail.com?subject=CookingAssistant"
+						target="_blank"
 					>henriette.steenhoff@gmail.com</a>
 				</p>
 				<p class="mt-0">
-					<a class="pl-0" style="font-size: 0.8rem;" href="https://www.twitter.com/frksteehoff">@frksteenhoff</a>
+					<a
+						class="pl-0"
+						style="font-size: 0.8rem;"
+						href="https://www.twitter.com/frksteehoff"
+					>@frksteenhoff</a>
 				</p>
 			</div>
 		</footer>
@@ -65,7 +72,7 @@ const AppProps = Vue.extend({
 	components: {}
 })
 export default class App extends AppProps {
-	recipes: RecipeObject[] = excelrecipes.concat(formrecipes)
+	recipes: RecipeObject[] = excelrecipes.concat(formrecipes);
 
 	created() {
 		this.$store.dispatch("setRecipes", this.recipes)
@@ -99,8 +106,8 @@ export default class App extends AppProps {
 <style>
 @import url("//fonts.googleapis.com/css?family=Permanent+Marker:300,400,600,700&amp;lang=en");
 @import url("//fonts.googleapis.com/css?family=Roboto:300,400,600,700&amp;lang=en");
-@import url('https://fonts.googleapis.com/css2?family=Sedgwick+Ave&amp;lang=eng');
-@import url('https://fonts.googleapis.com/css2?family=Homemade+Apple&amp;lang=eng');
+@import url("https://fonts.googleapis.com/css2?family=Sedgwick+Ave&amp;lang=eng");
+@import url("https://fonts.googleapis.com/css2?family=Homemade+Apple&amp;lang=eng");
 
 body {
 	margin: 0;
@@ -117,7 +124,7 @@ body {
 	font-family: "Roboto Light", "Roboto", "Arial", Helvetica, sans-serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-	color: #641E16;
+	color: #641e16;
 }
 
 #content {
@@ -134,7 +141,7 @@ nav {
 }
 
 a {
-	color: #641E16 !important;
+	color: #641e16 !important;
 	text-decoration: none !important;
 }
 
@@ -145,7 +152,7 @@ a:focus {
 a:hover,
 a.nav.link:hover {
 	text-decoration: none !important;
-	color:#000 !important;
+	color: #000 !important;
 }
 
 nav,
@@ -153,7 +160,7 @@ li a.nav-link {
 	color: #ffffff !important;
 	font-size: 1.25rem;
 	font-family: "Permanent Marker";
-	background-color: #bf988f !important;
+	background-color: #d6a2a2 !important;
 	text-decoration: none !important;
 	-webkit-tap-highlight-color: transparent;
 	outline: none !important;
@@ -187,7 +194,9 @@ p {
 	color: black !important;
 }
 
-p, h1, h2 {
+p,
+h1,
+h2 {
 	font-weight: normal;
 	padding-left: 21px;
 	padding-right: 21px;
@@ -221,8 +230,16 @@ li {
 }
 
 #insta_logo a:hover {
-	background-color: #bf988f;
+	background-color: #d6a2a2;
 	color: #ffffff;
+}
+
+.row {
+	margin: 0;
+}
+
+.container-fluid {
+	padding: 0;
 }
 
 footer {
@@ -231,7 +248,7 @@ footer {
 	margin: 0;
 	padding: 16px 0 16px 0;
 	padding-bottom: 40px;
-	background-color: #bf988f;
+	background-color: #d6a2a2;
 	color: #ffffff;
 }
 

--- a/src/components/BaseComponents/IngredientsList.vue
+++ b/src/components/BaseComponents/IngredientsList.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="ingredients pl-3 pt-3 pb-2 pr-3">
-		<h3 class="ingredients-header">Ingredienser</h3>
+		<h3 class="ingredients-header overflow-hidden">Ingredienser</h3>
 		<ul v-for="(item, index) in recipe.ingredients" :key="item.amount + item.unit + item.ingredient + index" class="mt-4">
 			<li itemprop="recipeIngredient">
 				{{ !item.amount ? "" : (Number(item.amount) * numberOfPortions) + " " + item.unit + " " + item.ingredient }}
@@ -26,8 +26,8 @@ p, li {
 }
 
 .ingredients {
-	background: #E8E8E8;
-	border: 1px #E8E8E8;
+	background: #f4efed;
+	border: 1px #f4efed;
 	border-radius: 2px;
 }
 

--- a/src/components/BaseComponents/PreparationsOverview.vue
+++ b/src/components/BaseComponents/PreparationsOverview.vue
@@ -2,23 +2,57 @@
 	<div>
 		<b-row>
 			<!-- Should only have servings or servings_w_type - otherwise something went wrong -->
-			<b-col cols="auto" :class="[hasServings && hasPrepTime ? 'ml-md-auto': '']" v-if="hasServings">
-				<b-icon icon="person"></b-icon> Antal: <span itemprop="recipeYield">{{ parseInt(recipe.servings) * numberOfPortions }}</span>
+			<b-col
+				cols="auto"
+				:class="['col-md-auto', hasServings && hasPrepTime ? 'ml-md-auto': '']"
+				v-if="hasServings"
+			>
+				<b-icon icon="person"></b-icon>Antal:
+				<span itemprop="recipeYield">{{ parseInt(recipe.servings) * numberOfPortions }}</span>
 			</b-col>
-			<b-col cols="auto" :class="[hasServings && hasPrepTime ? 'ml-md-auto': '']" v-if="hasServingsWithType">
-				<b-icon icon="person"></b-icon> Antal: <span itemprop="recipeYield">{{ recipe.servings_w_type.servings * numberOfPortions }} {{ recipe.servings_w_type.type }}</span>
+			<b-col
+				cols="auto"
+				:class="['col-md-auto', hasServings && hasPrepTime ? 'ml-md-auto': '']"
+				v-if="hasServingsWithType"
+			>
+				<b-icon icon="person" class="mr-2"></b-icon>Antal:
+				<span
+					itemprop="recipeYield"
+				>{{ recipe.servings_w_type.servings * numberOfPortions }} {{ recipe.servings_w_type.type }}</span>
 			</b-col>
-			<b-col cols="auto" :class="[hasPrepTime ? 'mr-md-auto': '']" v-if="hasPrepTime">
-				<b-icon icon="clock"></b-icon>  Tilberedningstid <span v-if="!hasOnlyActivePrepTime" v-b-tooltip.hover title="Hvor lang tid du aktivt skal bruge på retten">- aktiv</span>: <span itemprop="prepTime">{{ activePrepTime }}</span>
-				<span v-if="!hasOnlyActivePrepTime" itemprop="cookTime" class="ml-3"><span v-b-tooltip.hover title="Tid der går til hævning, kogning, bagning etc.">passiv:</span> {{ passivePrepTime }}</span>
-				<span v-if="!hasOnlyActivePrepTime" class="ml-3" v-b-tooltip.hover title="Den samlede tid det tager før du kan nyde det, du har lavet.">samlet: {{ totalCookTime }}</span>
-				<br>
+			<b-col v-if="hasPrepTime">
+				<b-row>
+					<b-col cols="12" md="auto" class="mb-xs-3">
+						<b-icon icon="clock" class="mr-2"></b-icon>Tilberedningstid
+					</b-col>
+					<b-col cols="12" md="auto" class="ml-sm-3">
+						<span
+							v-if="!hasOnlyActivePrepTime"
+							v-b-tooltip.hover
+							title="Hvor lang tid du aktivt skal bruge på retten"
+						>aktiv</span>:
+						<span itemprop="prepTime">{{ activePrepTime }}</span>
+					</b-col>
+					<b-col cols="12" md="auto">
+						<span v-if="!hasOnlyActivePrepTime" itemprop="cookTime" class="ml-3">
+							<span v-b-tooltip.hover class="text-bold" title="Tid der går til hævning, kogning, bagning etc.">
+								passiv:</span> {{ passivePrepTime }}
+						</span>
+					</b-col>
+					<b-col cols="12" md="auto">
+						<span
+							v-if="!hasOnlyActivePrepTime"
+							class="ml-3"
+							v-b-tooltip.hover
+							title="Den samlede tid det tager før du kan nyde det, du har lavet."
+						>samlet: {{ totalCookTime }}</span>
+						<br />
+					</b-col>
+				</b-row>
 			</b-col>
 		</b-row>
 		<b-row class="mt-2 mb-xs-3">
-			<b-col cols="auto">
-				Skalering
-			</b-col>
+			<b-col cols="auto">Skalering</b-col>
 			<b-col cols="auto" class="text-left">
 				<b-form-select
 					v-model="numberOfPortions"
@@ -47,11 +81,11 @@ export default class PreparationsOverview extends Vue {
 
 	toHoursAndMinutes(minutes: number) {
 		if (minutes % 60 === 0) {
-			return (minutes / 60) + " timer "
-		} else if ((minutes / 60) < 1) {
+			return minutes / 60 + " timer "
+		} else if (minutes / 60 < 1) {
 			return (minutes % 60) + " min"
 		}
-		return Math.floor((minutes / 60)) + " timer " + (minutes % 60) + " min"
+		return Math.floor(minutes / 60) + " timer " + (minutes % 60) + " min"
 	}
 
 	get hasOnlyActivePrepTime() {
@@ -86,8 +120,12 @@ export default class PreparationsOverview extends Vue {
 		return "preparationtime" in this.recipe && this.recipe.preparationtime
 	}
 
-	get portionScaling(): number [] {
-		return [0.25, 0.5, 0.75, 1, 1.5].concat(Array(10).fill(2).map((x, y) => x + y))
+	get portionScaling(): number[] {
+		return [0.25, 0.5, 0.75, 1, 1.5].concat(
+			Array(10)
+				.fill(2)
+				.map((x, y) => x + y)
+		)
 	}
 }
 </script>

--- a/src/components/BaseComponents/PreparationsOverview.vue
+++ b/src/components/BaseComponents/PreparationsOverview.vue
@@ -25,8 +25,8 @@
 					<b-col cols="12" md="auto" class="mb-xs-3 font-weight-bold">
 						<b-icon icon="clock" class="mr-2"></b-icon>Tilberedningstid
 					</b-col>
-					<b-col cols="12" md="auto" class="ml-sm-3">
-						<span
+					<b-col cols="12" md="auto">
+						<span class="ml-3"
 							v-if="!hasOnlyActivePrepTime"
 							v-b-tooltip.hover
 							title="Hvor lang tid du aktivt skal bruge på retten"

--- a/src/components/BaseComponents/PreparationsOverview.vue
+++ b/src/components/BaseComponents/PreparationsOverview.vue
@@ -7,7 +7,7 @@
 				:class="['col-md-auto', hasServings && hasPrepTime ? 'ml-md-auto': '']"
 				v-if="hasServings"
 			>
-				<b-icon icon="person"></b-icon>Antal:
+				<b-icon icon="person"></b-icon><span class="font-weight-bold">Antal: </span>
 				<span itemprop="recipeYield">{{ parseInt(recipe.servings) * numberOfPortions }}</span>
 			</b-col>
 			<b-col
@@ -15,14 +15,14 @@
 				:class="['col-md-auto', hasServings && hasPrepTime ? 'ml-md-auto': '']"
 				v-if="hasServingsWithType"
 			>
-				<b-icon icon="person" class="mr-2"></b-icon>Antal:
+				<b-icon icon="person" class="mr-2"></b-icon><span class="font-weight-bold">Antal: </span>
 				<span
 					itemprop="recipeYield"
 				>{{ recipe.servings_w_type.servings * numberOfPortions }} {{ recipe.servings_w_type.type }}</span>
 			</b-col>
 			<b-col v-if="hasPrepTime">
 				<b-row>
-					<b-col cols="12" md="auto" class="mb-xs-3">
+					<b-col cols="12" md="auto" class="mb-xs-3 font-weight-bold">
 						<b-icon icon="clock" class="mr-2"></b-icon>Tilberedningstid
 					</b-col>
 					<b-col cols="12" md="auto" class="ml-sm-3">
@@ -52,7 +52,9 @@
 			</b-col>
 		</b-row>
 		<b-row class="mt-2 mb-xs-3">
-			<b-col cols="auto">Skalering</b-col>
+			<b-col cols="auto" class="font-weight-bold">
+				<b-icon icon="bar-chart-fill" class="mr-2"></b-icon>Skalering
+			</b-col>
 			<b-col cols="auto" class="text-left">
 				<b-form-select
 					v-model="numberOfPortions"

--- a/src/components/BaseComponents/Section.vue
+++ b/src/components/BaseComponents/Section.vue
@@ -2,7 +2,7 @@
 	<b-container>
 		<b-row class="mt-3 mb-3">
 			<b-col>
-				<h1 class="ml-3">{{ header }}</h1>
+				<h1 class="ml-3 text-break">{{ header }}</h1>
 			</b-col>
 		</b-row>
 		<b-row class="mb-3">

--- a/src/components/BaseComponents/TextBox.vue
+++ b/src/components/BaseComponents/TextBox.vue
@@ -21,10 +21,10 @@ export default class TextBox extends Vue {
 
 <style scoped>
 	.pro-tip-box {
-		background-color: #E8E8E8;
+		background-color: #f4efed;
 		color: black;
 		padding: 1.5rem;
-		border: 1px #E8E8E8;
+		border: 1px #f4efed;
 		border-radius: 4px;
 	}
 

--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -145,7 +145,7 @@ p, li {
 }
 
 .slightly-colored {
-	background-color: #f6f6f6;
+	background-color: #f9f9f9;
 	padding: 1rem 2rem;
 	padding-top: 2rem;
 	margin-bottom: 1rem;

--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -1,8 +1,8 @@
 <template>
 	<div itemscope itemtype="http://schema.org/Recipe" class="mt-3 slightly-colored">
-		<b-row class="mb-4">
+		<b-row class="mb-4 text-wrap">
 			<b-col cols="12" class="text-center">
-				<h1 itemprop="name" class="pl-0 ml-0">{{ recipe.name }}</h1>
+				<h1 itemprop="name" class="text-break pl-0 ml-0" style="width:100%">{{ recipe.name }}</h1>
 			</b-col>
 		</b-row>
 		<b-row>

--- a/src/components/RecipeProcedure.vue
+++ b/src/components/RecipeProcedure.vue
@@ -7,7 +7,7 @@
 		</b-col>
 		<p v-if="recipe.steps.length <= 1" class="pl-0">Fremgangsmåde kommer snart!</p>
 		<ul v-for="(step, index) in recipe.steps" :key="step + index" class="mb-3">
-			<li itemprop="recipeInstructions" :class="['ml-0', (step.split(' ').length === 1) ? 'font-weight-bold' : '']">
+			<li itemprop="recipeInstructions" :class="['text-wrap', 'ml-0', (step.split(' ').length === 1) ? 'font-weight-bold' : '']">
 				{{ step }} <br/>
 			</li>
 		</ul>

--- a/src/components/RecipeProcedure.vue
+++ b/src/components/RecipeProcedure.vue
@@ -5,12 +5,14 @@
 				title="Procedure"
 			/>
 		</b-col>
+		<b-col class="pl-0">
 		<p v-if="recipe.steps.length <= 1" class="pl-0">Fremgangsmåde kommer snart!</p>
 		<ul v-for="(step, index) in recipe.steps" :key="step + index" class="mb-3">
-			<li itemprop="recipeInstructions" :class="['text-wrap', 'ml-0', (step.split(' ').length === 1) ? 'font-weight-bold' : '']">
-				{{ step }} <br/>
+			<li itemprop="recipeInstructions" :class="['ml-0', (step.split(' ').length === 1) ? 'font-weight-bold' : '']">
+				{{ step }}
 			</li>
 		</ul>
+		</b-col>
 	</b-row>
 </template>
 

--- a/src/data/formRecipes.json
+++ b/src/data/formRecipes.json
@@ -6156,6 +6156,11 @@
 				"ingredient": "chipotle, tørret"
 			},
 			{
+				"amount": "200",
+				"unit": "g",
+				"ingredient": "tomater, hakkede"
+			},
+			{
 				"amount": "2",
 				"unit": "spsk",
 				"ingredient": "eddike"
@@ -6188,7 +6193,7 @@
 			{
 				"amount": "1",
 				"unit": "tsk",
-				"ingredient": "løg, finthakket"
+				"ingredient": "løg, groft hakket"
 			},
 			{
 				"amount": "1",
@@ -6214,7 +6219,7 @@
 		"steps": [
 			"Marinade",
 			"Kom en halv liter vand i en gryde og brung det i kog. Når vandet koger, tilsæt da de tørrede chilier og lad dem blødgøres i 15 minutter.",
-			"Mens chilierne ligger i blød, skær da kødet id u 2x2cm stykker og krydr med salt og peber.",
+			"Mens chilierne ligger i blød, skær da kødet ud i 2x2cm stykker og krydr med salt og peber.",
 			"Kom alle marinadeingredienserne (chili, chipotle, tomater, eddike, hvidløg, oregano, paprika og spidskommen) i en blender sammen med chilierne og bland til du får en lind masse.",
 			"Kom marinaden på kødet og lad det stå i 3-4 timer eller natten over.",
 			"Birria gryderet",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,28 +1,65 @@
 <template>
 	<div class="home">
-		<b-carousel
-			id="carousel-fade"
-			style="text-shadow: 0px 0px 2px #000"
-			fade
-			indicators
-			:interval="2000"
-			img-width="768"
-			img-height="360"
-		>
-			<b-carousel-slide caption="Jordbærtærte" text="Opskrifter til alle anledninger" :img-src="require('@/assets/carousel/jordbaertaerte.jpg')"></b-carousel-slide>
-			<b-carousel-slide caption="Stegte dumplings" text="Find insspiration fra det Asiatiske køkken" :img-src="require('@/assets/carousel/dumpling_dip.jpg')"></b-carousel-slide>
-			<b-carousel-slide caption="Lemon meringue pie" text="Find både brød, kager og andre søde sager" :img-src="require('@/assets/carousel/front.jpg')"></b-carousel-slide>
-			<b-carousel-slide caption="Bao" text="Prøv kræfter med lækre, asiatiske retter" :img-src="require('@/assets/carousel/bao_fyldt2.jpg')"></b-carousel-slide>
-			<b-carousel-slide caption="Pasta" text="Prøv noget nyt, eller lav en kending" :img-src="require('@/assets/carousel/pasta_sliced.jpg')"></b-carousel-slide>
-			<b-carousel-slide caption="Gulerodsmuffins" text="Svampede muffins med en lækker ostecreme" :img-src="require('@/assets/carousel/gulerodsmuffins.jpg')"></b-carousel-slide>
-			<b-carousel-slide caption="Ciabatta" text="Prøv noget nyt, eller lav en kending" :img-src="require('@/assets/carousel/ciabatta.jpg')"></b-carousel-slide>
-			<b-carousel-slide caption="Kanelsnurrer" text="Hvis der er noget der mangler, så sig endelig til" :img-src="require('@/assets/carousel/kanelsnurrer.jpg')"></b-carousel-slide>
-		</b-carousel>
-	<Section
-		class="mt-5"
-		header="Madglæde"
-		:content="welcomList.join('*')"
-	/>
+		<b-container>
+			<b-row class="mt-lg-4 justify-content-center">
+				<b-col cols="12" lg="8" class="p-0">
+					<b-carousel
+						id="carousel-fade"
+						style="text-shadow: 0px 0px 2px #000"
+						class="p-0"
+						fade
+						indicators
+						:interval="2000"
+						img-width="768"
+						img-height="360"
+					>
+						<b-carousel-slide
+							caption="Jordbærtærte"
+							text="Opskrifter til alle anledninger"
+							:img-src="require('@/assets/carousel/jordbaertaerte.jpg')"
+						></b-carousel-slide>
+						<b-carousel-slide
+							caption="Stegte dumplings"
+							text="Find insspiration fra det Asiatiske køkken"
+							:img-src="require('@/assets/carousel/dumpling_dip.jpg')"
+						></b-carousel-slide>
+						<b-carousel-slide
+							caption="Lemon meringue pie"
+							text="Find både brød, kager og andre søde sager"
+							:img-src="require('@/assets/carousel/front.jpg')"
+						></b-carousel-slide>
+						<b-carousel-slide
+							caption="Bao"
+							text="Prøv kræfter med lækre, asiatiske retter"
+							:img-src="require('@/assets/carousel/bao_fyldt2.jpg')"
+						></b-carousel-slide>
+						<b-carousel-slide
+							caption="Pasta"
+							text="Prøv noget nyt, eller lav en kending"
+							:img-src="require('@/assets/carousel/pasta_sliced.jpg')"
+						></b-carousel-slide>
+						<b-carousel-slide
+							caption="Gulerodsmuffins"
+							text="Svampede muffins med en lækker ostecreme"
+							:img-src="require('@/assets/carousel/gulerodsmuffins.jpg')"
+						></b-carousel-slide>
+						<b-carousel-slide
+							caption="Ciabatta"
+							text="Prøv noget nyt, eller lav en kending"
+							:img-src="require('@/assets/carousel/ciabatta.jpg')"
+						></b-carousel-slide>
+						<b-carousel-slide
+							caption="Kanelsnurrer"
+							text="Hvis der er noget der mangler, så sig endelig til"
+							:img-src="require('@/assets/carousel/kanelsnurrer.jpg')"
+						></b-carousel-slide>
+					</b-carousel>
+				</b-col>
+			</b-row>
+			<b-row>
+				<Section class="mt-5" header="Madglæde" :content="welcomeTextList.join('*')" />
+			</b-row>
+		</b-container>
 	</div>
 </template>
 
@@ -31,9 +68,9 @@ import { Vue, Component } from "vue-property-decorator"
 import Section from "@/components/BaseComponents/Section.vue"
 
 const AppProps = Vue.extend({
-	props: {
-	}
+	props: {}
 })
+
 @Component({
 	components: {
 		Section
@@ -53,9 +90,9 @@ export default class Home extends AppProps {
 			caption: "Kanelsnurrer",
 			src: "@/assets/carousel/kanelsnurrer.png"
 		}
-	]
+	];
 
-	welcomList: string[] = [
+	welcomeTextList: string[] = [
 		"Velkommen til!",
 		"På denne side findes der et bredt udvalg af de opskrifter, som jeg benytter meget i hverdagen og som jeg synes er så gode, at de burde deles med verden -- eller hvertfald Danmark.",
 		"Min idé med disse opskrifter er at give en kort og præcis beskrivelse af ingredienser og fremgangsmåder samt at undgå for meget sniksnak og lange beskrivende tekster (bortset fra denne).",
@@ -63,12 +100,12 @@ export default class Home extends AppProps {
 		"Nogle opskrifter er stærkt inspireret af opskrifter jeg har fundet på nettet. Her har jeg linket til originalen i den pågældende opskrift. Disse opskrifter har jeg som oftest forfinet lidt/ændret lidt i mængder eller ingredienser fra originalen.",
 		"Jeg håber du finder noget du kan lide!",
 		"Jeg er hverken fotograf, eller designer, men jeg er softwareingeniør. Billederne du finder her har jeg selv taget og design og udvikling af denne side er mit hobbyprojekt. Skulle du opleve fejl eller mangler på siden, at noget der ikke er beskrevet godt nok, eller har du nogle gode idéer til hvordan siden kunne gøres bedre, er du mere end velkommen til at kontakte mig på en af medierne angivet nedenunder."
-	]
+	];
 }
 </script>
 
 <style>
-	#carousel-fade div p {
-		color: white !important;
-	}
+#carousel-fade div p {
+	color: white !important;
+}
 </style>


### PR DESCRIPTION
## 🔧 Functionality
* Made sure recipe steps are separated on new line (previously did not wrap if text from several list items could be on one line
New (left), Previous (right)
![image](https://user-images.githubusercontent.com/6978512/201513003-d35679d0-f284-407f-953c-6865798c18d2.png)


* Updated recipe and navbar color scheme (see images below)
* Made image on home page smaller on big screens
New (left), Previous (right)
![image](https://user-images.githubusercontent.com/6978512/201512679-efe2bbec-dd0f-4376-b38d-354c9b900e6a.png)


* Added bold face to important information about the recipes
New (left), Previous (right)

Big screens
![image](https://user-images.githubusercontent.com/6978512/201512739-07946dec-0cab-4386-bf8c-f08eff18d03d.png)

Smaller screens
![image](https://user-images.githubusercontent.com/6978512/201512912-319d3542-ac59-4bb9-af69-5e5edeb42cf0.png)


* Hid overflow in ingredients list on smaller screens 
New (left), Previous (right)
![image](https://user-images.githubusercontent.com/6978512/201512966-88e761e8-f0c4-42e6-ab20-f7f556056c2c.png)
